### PR TITLE
Simplify the library API calls using the windows-link macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc", "i686-pc-windows
 
 [dependencies]
 image = "0.25"
-libloading = "0.8.7"
 thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive"] }
+windows-link = "0.1.3"
 
 [dev-dependencies]
 imageproc = "0.25"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub enum OneOcrError {
     #[error("Invalid model decryption key: {0}")]
     InvalidModelKey(String),
 
-    #[error("Failed to run ocr API {result}, result: {message}")]
+    #[error("Failed to run OCR API (code: {result}): {message}")]
     OcrApiError { result: i32, message: String },
 
     #[error("Other error: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,9 +7,6 @@ pub enum OneOcrError {
     #[error("Image format not supported: {0}")]
     ImageFormatError(String),
 
-    #[error("Failed to load library: {0}")]
-    LibraryLoadError(#[from] libloading::Error),
-
     #[error("Failed to load model file: {0}")]
     ModelFileLoadError(String),
 
@@ -17,7 +14,7 @@ pub enum OneOcrError {
     InvalidModelKey(String),
 
     #[error("Failed to run ocr API {result}, result: {message}")]
-    OcrApiError { result: i64, message: String },
+    OcrApiError { result: i32, message: String },
 
     #[error("Other error: {0}")]
     Other(String),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,43 +1,40 @@
-use std::ffi::c_char;
+use std::ffi::{c_char, c_void};
+use windows_link::link;
 
-pub type CreateOcrInitOptions = unsafe extern "C" fn(*mut i64) -> i64;
-pub type OcrInitOptionsSetUseModelDelayLoad = unsafe extern "C" fn(i64, c_char) -> i64;
-pub type CreateOcrPipeline = unsafe extern "C" fn(
+link!("oneocr.dll"  "system"  fn CreateOcrInitOptions(init_option: *mut *mut c_void) -> i32);
+link!("oneocr.dll"  "system"  fn OcrInitOptionsSetUseModelDelayLoad(init_option: *mut c_void) -> i32);
+link!("oneocr.dll"  "system"  fn CreateOcrPipeline(
     model_path: *const c_char,
     key: *const c_char,
-    ctx: i64,
-    pipeline: *mut i64,
-) -> i64;
-
-pub type CreateOcrProcessOptions = unsafe extern "C" fn(*mut i64) -> i64;
-pub type OcrProcessOptionsGetMaxRecognitionLineCount = unsafe extern "C" fn(i64, *mut i64) -> i64;
-pub type OcrProcessOptionsSetMaxRecognitionLineCount = unsafe extern "C" fn(i64, i64) -> i64;
-pub type OcrProcessOptionsGetResizeResolution =
-    unsafe extern "C" fn(i64, *mut i64, *mut i64) -> i64;
-pub type OcrProcessOptionsSetResizeResolution = unsafe extern "C" fn(i64, i64, i64) -> i64;
-
-/// Image resolution must be great than 50*50, otherwise it will return error code 3.
-/// For images with a resolution less than 50*50, you should manually scale up the image first.
-pub type RunOcrPipeline = unsafe extern "C" fn(i64, *const RawImage, i64, *mut i64) -> i64;
-
-pub type GetImageAngle = unsafe extern "C" fn(i64, *mut f32) -> i64;
-
-pub type GetOcrLineCount = unsafe extern "C" fn(i64, *mut i64) -> i64;
-pub type GetOcrLine = unsafe extern "C" fn(i64, i64, *mut i64) -> i64;
-pub type GetOcrLineContent = unsafe extern "C" fn(i64, *mut i64) -> i64;
-pub type GetOcrLineBoundingBox = unsafe extern "C" fn(i64, *mut *const RawBBox) -> i64;
-pub type GetOcrLineStyle = unsafe extern "C" fn(i64, *mut i32, *mut f32) -> i64;
-
-pub type GetOcrLineWordCount = unsafe extern "C" fn(i64, *mut i64) -> i64;
-pub type GetOcrWord = unsafe extern "C" fn(i64, i64, *mut i64) -> i64;
-pub type GetOcrWordContent = unsafe extern "C" fn(i64, *mut i64) -> i64;
-pub type GetOcrWordBoundingBox = unsafe extern "C" fn(i64, *mut *const RawBBox) -> i64;
-pub type GetOcrWordConfidence = unsafe extern "C" fn(i64, *mut f32) -> i64;
-
-pub type ReleaseOcrResult = unsafe extern "C" fn(i64);
-pub type ReleaseOcrInitOptions = unsafe extern "C" fn(i64);
-pub type ReleaseOcrPipeline = unsafe extern "C" fn(i64);
-pub type ReleaseOcrProcessOptions = unsafe extern "C" fn(i64);
+    ctx: *mut c_void,
+    pipeline: *mut *mut c_void
+) -> i32);
+link!("oneocr.dll"  "system"  fn CreateOcrProcessOptions(option: *mut *mut c_void) -> i32);
+link!("oneocr.dll"  "system"  fn OcrProcessOptionsGetMaxRecognitionLineCount(option: *mut c_void, count: *mut i32) -> i32);
+link!("oneocr.dll"  "system"  fn OcrProcessOptionsSetMaxRecognitionLineCount(option: *mut c_void, count: i32) -> i32);
+link!("oneocr.dll"  "system"  fn OcrProcessOptionsGetResizeResolution(option: *mut c_void, width: *mut i64, height: *mut i64) -> i32);
+link!("oneocr.dll"  "system"  fn OcrProcessOptionsSetResizeResolution   (option: *mut c_void, width: i32, height: i32) -> i32);
+link!("oneocr.dll"  "system"  fn RunOcrPipeline(
+    pipeline: *mut c_void,
+    image: *const RawImage,
+    process_options: *mut c_void,
+    result: *mut *mut c_void
+) -> i32);
+link!("oneocr.dll"  "system"  fn GetImageAngle(pipeline: *mut c_void, angle: *mut f32) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLineCount(result: *mut c_void, count: *mut i64) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLine(result: *mut c_void, index: i64, line: *mut *mut c_void) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLineContent(line: *mut c_void, content: *mut *const c_char) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLineBoundingBox(line: *mut c_void, bbox: *mut *const RawBBox) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLineStyle(line: *mut c_void, style: *mut i32, confidence: *mut f32) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrLineWordCount(line: *mut c_void, count: *mut i64) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrWord(line: *mut c_void, index: i64, word: *mut *mut c_void) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrWordContent(word: *mut c_void, content: *mut *const c_char) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrWordBoundingBox(word: *mut c_void, bbox: *mut *const RawBBox) -> i32);
+link!("oneocr.dll"  "system"  fn GetOcrWordConfidence(word: *mut c_void, confidence: *mut f32) -> i32);
+link!("oneocr.dll"  "system"  fn ReleaseOcrResult(result: *mut c_void));
+link!("oneocr.dll"  "system"  fn ReleaseOcrInitOptions(init_options: *mut c_void));
+link!("oneocr.dll"  "system"  fn ReleaseOcrPipeline(pipeline: *mut c_void));
+link!("oneocr.dll"  "system"  fn ReleaseOcrProcessOptions(process_options: *mut c_void));
 
 /// This `RawImage` struct represents an image in a format suitable for OCR processing. Used for FFI.
 ///  - t: Type of the image (e.g., RGB, RGBA).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,44 +18,6 @@ pub use ocr_word::OcrWord;
 pub(crate) const ONE_OCR_MODEL_FILE_NAME: &str = "oneocr.onemodel";
 pub(crate) const ONE_OCR_MODEL_KEY: &str = r#"kj)TGtrK>f]b[Piow.gU+nC@s""""""4"#;
 
-/// A macro to load a symbol from the library.
-/// This macro takes three arguments:
-/// - `$library`: The library from which to load the symbol.
-/// - `$var_name`: The name of the variable to store the loaded symbol.
-/// - `$symbol_name_type`: The type of the symbol to load.
-///
-/// This macro is used to simplify the process of loading symbols from the library.
-/// It helps to avoid repetitive code and makes the code cleaner and more readable.
-macro_rules! load_symbol {
-    ($library:expr, $var_name:ident, $symbol_name_type:ident) => {
-        let $var_name: libloading::Symbol<$symbol_name_type> =
-            unsafe { $library.get(stringify!($symbol_name_type).as_bytes())? };
-    };
-}
-
-pub(crate) use load_symbol;
-
-/// A macro to attempt to load a symbol and call it, for use in contexts like `drop`
-/// Errors during symbol loading are logged to stderr, and the call is skipped.
-/// - `$library`: The library instance.
-/// - `$symbol_name_type`: The type of the FFI function (also used as the symbol name).
-/// - $($arg:expr),*`: The arguments to pass to the function if loaded successfully.
-macro_rules! release_ocr_resource {
-    ($library:expr, $symbol_name_type:ident, $($arg:expr),* ) => {
-        match unsafe { $library.get::<$symbol_name_type>(stringify!($symbol_name_type).as_bytes()) } {
-            Ok(func_symbol) => {
-                unsafe { func_symbol($($arg),*) };
-            }
-            Err(_) => {
-                // Ignore the error, as this is best effort
-                // and we are in the drop context.
-            }
-        }
-    };
-}
-
-pub(crate) use release_ocr_resource;
-
 /// A macro to check the result of an OCR call and return an error if it fails.
 /// This macro takes an expression `$call` and an error message `$err_msg`.
 /// If the result of `$call` is not 0, it returns an `OneOcrError::OcrApiError` error with the provided message.

--- a/src/ocr_engine.rs
+++ b/src/ocr_engine.rs
@@ -34,9 +34,6 @@ impl OcrEngine {
             "Failed to create init options"
         );
 
-        // The FFI function OcrInitOptionsSetUseModelDelayLoad expects a c_char (i8).
-        // In C, char can be signed or unsigned by default depending on the compiler/platform.
-        // Rust's c_char is i8. Assuming 0 is a valid value for false.
         check_ocr_call!(
             unsafe { OcrInitOptionsSetUseModelDelayLoad(init_options) },
             "Failed to set model delay load"

--- a/src/ocr_result.rs
+++ b/src/ocr_result.rs
@@ -1,7 +1,7 @@
 use crate::errors::OneOcrError;
 use crate::ocr_line::OcrLine;
 use serde::Serialize;
-use std::os::raw::c_void;
+use std::ffi::c_void;
 use std::ptr;
 
 // FFI types

--- a/src/ocr_result.rs
+++ b/src/ocr_result.rs
@@ -1,58 +1,51 @@
 use crate::errors::OneOcrError;
 use crate::ocr_line::OcrLine;
-use libloading::Library;
 use serde::Serialize;
+use std::os::raw::c_void;
+use std::ptr;
 
 // FFI types
 use crate::ffi::{GetImageAngle, GetOcrLine, GetOcrLineCount, ReleaseOcrResult};
 // Macros
-use crate::{check_ocr_call, load_symbol, release_ocr_resource};
+use crate::check_ocr_call;
 
 /// The `OcrResult` struct represents the result of an OCR operation.
 /// It contains the recognized text lines, their bounding boxes, and the image angle.
 #[derive(Debug, Serialize)]
-pub struct OcrResult<'a> {
+pub struct OcrResult {
     #[serde(skip_serializing)]
-    lib: &'a Library,
-    #[serde(skip_serializing)]
-    result_handle: i64,
-    pub lines: Vec<OcrLine<'a>>,
+    result_handle: *mut c_void,
+    pub lines: Vec<OcrLine>,
     pub image_angle: f32,
 }
 
-impl<'a> OcrResult<'a> {
+impl OcrResult {
     pub(crate) fn new(
-        lib: &'a Library,
-        result_handle: i64,
+        result_handle: *mut c_void,
         word_level_detail: bool,
     ) -> Result<Self, OneOcrError> {
-        load_symbol!(lib, get_ocr_line_count, GetOcrLineCount);
-        load_symbol!(lib, get_ocr_line, GetOcrLine);
-        load_symbol!(lib, get_image_angle, GetImageAngle);
-
         let mut line_count: i64 = 0;
         check_ocr_call!(
-            unsafe { get_ocr_line_count(result_handle, &mut line_count) },
+            unsafe { GetOcrLineCount(result_handle, &mut line_count) },
             "Failed to get line count"
         );
         let mut lines = Vec::with_capacity(line_count as usize);
         for i in 0..line_count {
-            let mut line: i64 = 0;
+            let mut line: *mut c_void = ptr::null_mut();
             check_ocr_call!(
-                unsafe { get_ocr_line(result_handle, i, &mut line) },
+                unsafe { GetOcrLine(result_handle, i, &mut line) },
                 "Failed to get line"
             );
-            let ocr_line = OcrLine::new(lib, line, word_level_detail)?;
+            let ocr_line = OcrLine::new(line, word_level_detail)?;
             lines.push(ocr_line);
         }
         let mut angle: f32 = 0.0;
         check_ocr_call!(
-            unsafe { get_image_angle(result_handle, &mut angle) },
+            unsafe { GetImageAngle(result_handle, &mut angle) },
             "Failed to get image angle"
         );
 
         Ok(Self {
-            lib,
             result_handle,
             lines,
             image_angle: angle,
@@ -60,8 +53,8 @@ impl<'a> OcrResult<'a> {
     }
 }
 
-impl Drop for OcrResult<'_> {
+impl Drop for OcrResult {
     fn drop(&mut self) {
-        release_ocr_resource!(self.lib, ReleaseOcrResult, self.result_handle);
+        unsafe { ReleaseOcrResult(self.result_handle) };
     }
 }

--- a/src/ocr_word.rs
+++ b/src/ocr_word.rs
@@ -1,13 +1,13 @@
 use crate::bounding_box::BoundingBox;
 use crate::errors::OneOcrError;
-use libloading::Library;
 use serde::Serialize;
-use std::ffi::{CStr, c_char};
+use std::ffi::{CStr, c_char, c_void};
+use std::ptr;
 
 // FFI types used by this module
 use crate::ffi::{GetOcrWordBoundingBox, GetOcrWordConfidence, GetOcrWordContent, RawBBox};
 // Macros
-use crate::{check_ocr_call, load_symbol};
+use crate::check_ocr_call;
 
 /// The `OcrWord` struct represents a word recognized by the OCR engine.
 /// It contains the recognized word, its confidence score, and its bounding box.
@@ -19,22 +19,18 @@ pub struct OcrWord {
 }
 
 impl OcrWord {
-    pub(crate) fn new(lib: &Library, word_handle: i64) -> Result<Self, OneOcrError> {
-        load_symbol!(lib, get_ocr_word_content, GetOcrWordContent);
-        load_symbol!(lib, get_ocr_word_bounding_box, GetOcrWordBoundingBox);
-        load_symbol!(lib, get_ocr_word_confidence, GetOcrWordConfidence);
-
-        let mut word_content: i64 = 0;
+    pub(crate) fn new(word_handle: *mut c_void) -> Result<Self, OneOcrError> {
+        let mut word_content: *const c_char = ptr::null();
         check_ocr_call!(
-            unsafe { get_ocr_word_content(word_handle, &mut word_content) },
+            unsafe { GetOcrWordContent(word_handle, &mut word_content) },
             "Failed to get word content"
         );
-        let word_content_cstr = unsafe { CStr::from_ptr(word_content as *const c_char) };
+        let word_content_cstr = unsafe { CStr::from_ptr(word_content) };
         let word_content_str = word_content_cstr.to_string_lossy().to_string();
 
-        let mut bounding_box_ptr: *const RawBBox = std::ptr::null();
+        let mut bounding_box_ptr: *const RawBBox = ptr::null();
         check_ocr_call!(
-            unsafe { get_ocr_word_bounding_box(word_handle, &mut bounding_box_ptr) },
+            unsafe { GetOcrWordBoundingBox(word_handle, &mut bounding_box_ptr) },
             "Failed to get word bounding box"
         );
 
@@ -45,12 +41,12 @@ impl OcrWord {
             });
         }
 
-        let raw_bbox = unsafe { std::ptr::read(bounding_box_ptr) };
+        let raw_bbox = unsafe { ptr::read(bounding_box_ptr) };
         let bounding_box = BoundingBox::new(raw_bbox);
 
         let mut confidence: f32 = 0.0;
         check_ocr_call!(
-            unsafe { get_ocr_word_confidence(word_handle, &mut confidence) },
+            unsafe { GetOcrWordConfidence(word_handle, &mut confidence) },
             "Failed to get word confidence"
         );
 


### PR DESCRIPTION
* Remove the `libloading` crate
* Using the `link!` macro from the `windows-link` crate to simplify the API calls greatly
-----
This pull request introduces significant changes to the OneOCR codebase, focusing on replacing the dynamic library loading approach with a static linking mechanism using the `windows-link` crate. This simplifies the codebase, improves type safety, and enhances maintainability. Key changes include the removal of macros for symbol loading, updates to FFI function signatures, and adjustments to error handling and type definitions.

### Transition to Static Linking

* Replaced dynamic library loading (`libloading`) with static linking using the `windows-link` crate for all FFI functions in `src/ffi.rs`, improving type safety and reducing runtime errors.

### Updates to FFI Function Signatures and Types

* Updated FFI function signatures to use `*mut c_void` instead of `i64` for pointers, aligning with the new static linking approach. This change affects multiple methods in `src/ffi.rs` and `src/ocr_engine.rs`. [[1]](diffhunk://#diff-18d30fdf2c8ebc20bcd7265f8dbc8a53634237ae0ac19ef1e69a64e2a72dcaa2L1-R37) [[2]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL2-R41) [[3]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL70-R60) [[4]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL83-L90)
* Changed the `OcrApiError` type in `src/errors.rs` to use `i32` instead of `i64` for the `result` field, reflecting the updated FFI function return types.

### Removal of Redundant Code

* Removed macros (`load_symbol` and `release_ocr_resource`) used for dynamic symbol loading in `src/lib.rs`, as they are no longer needed with static linking.
* Eliminated redundant `libloading` imports and references in files such as `src/ocr_engine.rs` and `src/ocr_line.rs`. [[1]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL2-R41) [[2]](diffhunk://#diff-4d2a251494edb4df7b06d982857692c7fdf4fef7bd491c316f8d814e08a97e65L4-R42)

### Adjustments to `OcrEngine`

* Simplified the `OcrEngine` struct by removing the `Library` field, as dynamic library management is no longer required. Updated related methods to directly call statically linked functions. [[1]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL2-R41) [[2]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL248-R201)
* Updated methods like `get_max_recognition_line_count`, `set_resize_resolution`, and `run_pipeline` to reflect the new FFI function signatures and type changes. [[1]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL99-R89) [[2]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL139-R117) [[3]](diffhunk://#diff-ff03f5e052984ce0a72c9e31789138a6f34b985d055731ecc70b66e30fe2d3fcL209-R173)

### Adjustments to `OcrLine`

* Updated the `OcrLine` struct to use `*mut c_void` for the `line_handle` field and modified related methods to use the new static linking approach. [[1]](diffhunk://#diff-4d2a251494edb4df7b06d982857692c7fdf4fef7bd491c316f8d814e08a97e65L4-R42) [[2]](diffhunk://#diff-4d2a251494edb4df7b06d982857692c7fdf4fef7bd491c316f8d814e08a97e65L59-L94)
* Simplified the `get_line_style` method by removing dynamic symbol loading and directly calling the statically linked function. 