### PR TITLE
Improves interoperability for OCR-related data types

### DIFF
--- a/src/bounding_box.rs
+++ b/src/bounding_box.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::ffi::RawBBox;
 
 /// This `Point` struct represents a point in 2D space with X and Y coordinates.
-#[derive(Debug, Clone, Copy, Default, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq)]
 pub struct Point {
     pub x: f32,
     pub y: f32,
@@ -16,7 +16,7 @@ impl std::fmt::Display for Point {
 }
 
 /// This `BoundingBox` struct represents a bounding box in 2D space, used for OCR to tightly enclose detected text.
-#[derive(Debug, Clone, Copy, Default, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq)]
 pub struct BoundingBox {
     pub top_left: Point,
     pub top_right: Point,

--- a/src/ocr_options.rs
+++ b/src/ocr_options.rs
@@ -1,12 +1,12 @@
 /// A simple width×height pair.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Resolution {
     pub width: i32,
     pub height: i32,
 }
 
 /// Configuration for OCR processing behavior.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct OcrOptions {
     /// The maximum number of lines that can be recognized.
     /// Default is 100, range is 0-1000.

--- a/src/ocr_options.rs
+++ b/src/ocr_options.rs
@@ -6,7 +6,7 @@ pub struct Resolution {
 }
 
 /// Configuration for OCR processing behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OcrOptions {
     /// The maximum number of lines that can be recognized.
     /// Default is 100, range is 0-1000.

--- a/src/ocr_word.rs
+++ b/src/ocr_word.rs
@@ -11,7 +11,7 @@ use crate::check_ocr_call;
 
 /// The `OcrWord` struct represents a word recognized by the OCR engine.
 /// It contains the recognized word, its confidence score, and its bounding box.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct OcrWord {
     pub text: String,
     pub confidence: f32,


### PR DESCRIPTION
This pull request introduces several changes to improve the consistency and usability of data structures in the codebase by adding new trait derivations. The most notable changes include adding `PartialEq`, `Eq`, and `Hash` implementations to several structs, which enhances their comparability and usability in collections like `HashSet` or `HashMap`.

### Enhancements to struct trait derivations:

* `src/bounding_box.rs`:
  - Added `PartialEq` to the `Point` struct, enabling direct equality comparisons between `Point` instances.
  - Added `PartialEq` to the `BoundingBox` struct, allowing equality checks for bounding boxes.

* `src/ocr_options.rs`:
  - Added `PartialEq`, `Eq`, and `Hash` to the `Resolution` struct, making it usable in hashed collections and comparable for equality.
  - Added `PartialEq`, `Eq`, and `Hash` to the `OcrOptions` struct, improving its usability in contexts requiring equality checks or hashing.

* `src/ocr_word.rs`:
  - Added `Clone` and `PartialEq` to the `OcrWord` struct, enabling cloning and equality comparisons for OCR word instances.